### PR TITLE
app: fix reading .txt files

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,9 +3,10 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
 student_files = [doc for doc in os.listdir() if doc.endswith('.txt')]
-student_notes = [open(_file, encoding='utf-8').read()
-                 for _file in student_files]
-
+student_notes = []
+for _file in student_files:
+    with open(_file, encoding='utf-8') as f:
+        student_notes.append(f.read())
 
 def vectorize(Text): return TfidfVectorizer().fit_transform(Text).toarray()
 def similarity(doc1, doc2): return cosine_similarity([doc1, doc2])


### PR DESCRIPTION
Safely read .txt files using `with open()` to avoid resource leak.